### PR TITLE
Fix Vite builds to emit ESM for main and preload

### DIFF
--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     emptyOutDir: false,
     lib: {
       entry: path.resolve(__dirname, 'src/main/main.ts'),
-      formats: ['cjs'],
+      formats: ['es'],
       fileName: () => 'main.js',
     },
     rollupOptions: {

--- a/vite.preload.config.ts
+++ b/vite.preload.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     emptyOutDir: false,
     lib: {
       entry: path.resolve(__dirname, 'src/preload/index.ts'),
-      formats: ['cjs'],
+      formats: ['es'],
       fileName: () => 'index.js',
     },
     rollupOptions: {


### PR DESCRIPTION
## Summary
- update the Electron main and preload Vite builds to emit ES modules instead of CommonJS
- keep the generated filenames the same while matching the package's module type

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc621a36108326ae94dcc840e9a623