### PR TITLE
Improve WebSurface integration

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -114,7 +114,7 @@ app.whenReady().then(() => {
       if (mainWindow) {
         mainWindow.removeBrowserView(webview);
       }
-      (webview.webContents as any).destroy();
+      webview.webContents.destroy();
       webviews.delete(id);
     }
   });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,10 @@
 // electron/preload.ts
 import { contextBridge, ipcRenderer } from 'electron'
+
+contextBridge.exposeInMainWorld('appApi', {
+  getAppVersion: () => ipcRenderer.invoke('app:get-version'),
+})
+
 contextBridge.exposeInMainWorld('webview', {
   create: (id: string, partition?: string) => ipcRenderer.invoke('view:create', { id, partition }),
   setBounds: (id: string, b: { x: number; y: number; width: number; height: number }) =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -42,8 +42,8 @@ const App = () => {
           v{version || '...'}
         </footer>
       </aside>
-      <main className="flex flex-1 flex-col items-center justify-center gap-3">
-        //add style to the webSurface, I need it to be in line with the sidebar, so it just occupy the space from the main tag 
+      <main className="relative flex flex-1">
+        {/* The BrowserView is positioned behind this placeholder */}
         <WebSurface url="https://www.google.com" paddingTop={48} paddingLeft={260} className="absolute inset-0" />
       </main>
     </div>

--- a/src/renderer/src/components/WebSurface.tsx
+++ b/src/renderer/src/components/WebSurface.tsx
@@ -9,43 +9,114 @@ type Props = {
   paddingLeft?: number         // offsets for your sidebar
 }
 
-export default function WebSurface({ url, partition, className, paddingTop=0, paddingLeft=0 }: Props) {
-  const id = useId().replace(/:/g,'')   // stable-ish ID per mount
+export default function WebSurface({ url, partition, className, paddingTop = 0, paddingLeft = 0 }: Props) {
+  const id = useId().replace(/:/g, '') // stable-ish ID per mount
   const hostRef = useRef<HTMLDivElement>(null)
+  const readyRef = useRef<Promise<void> | null>(null)
+  const updateBoundsRef = useRef<() => void>(() => {})
+
+  const updateBounds = () => {
+    const el = hostRef.current
+    if (!el) {
+      return
+    }
+    const r = el.getBoundingClientRect()
+    window.webview.setBounds(id, {
+      x: Math.max(0, Math.floor(r.left)) + paddingLeft,
+      y: Math.max(0, Math.floor(r.top)) + paddingTop,
+      width: Math.max(1, Math.floor(r.width)),
+      height: Math.max(1, Math.floor(r.height)),
+    })
+  }
+
+  updateBoundsRef.current = updateBounds
 
   useEffect(() => {
-    let ro: ResizeObserver | null = null
-    let alive = true
+    const host = hostRef.current
+    if (!host) {
+      return
+    }
 
-    const mount = async () => {
-      await window.webview.create(id, partition)
-      await window.webview.load(id, url)
-      const updateBounds = () => {
-        const el = hostRef.current!
-        const r = el.getBoundingClientRect()
-        window.webview.setBounds(id, {
-          x: Math.max(0, Math.floor(r.left)) + paddingLeft,
-          y: Math.max(0, Math.floor(r.top)) + paddingTop,
-          width: Math.max(1, Math.floor(r.width)),
-          height: Math.max(1, Math.floor(r.height)),
-        })
+    let disposed = false
+    let resizeObserver: ResizeObserver | null = null
+
+    const handleResize = () => {
+      updateBoundsRef.current()
+    }
+
+    const readyPromise = (async () => {
+      try {
+        await window.webview.create(id, partition)
+        if (disposed) {
+          await window.webview.destroy(id)
+          return
+        }
+
+        updateBoundsRef.current()
+
+        if (typeof ResizeObserver !== 'undefined') {
+          resizeObserver = new ResizeObserver(() => {
+            updateBoundsRef.current()
+          })
+          resizeObserver.observe(host)
+          if (document.body) {
+            resizeObserver.observe(document.body)
+          }
+        }
+
+        window.addEventListener('resize', handleResize)
+      } catch (error) {
+        console.error('Failed to create webview', error)
+        throw error
       }
-      updateBounds()
-      ro = new ResizeObserver(updateBounds)
-      ro.observe(document.body)
-      ro.observe(hostRef.current!)
-      window.addEventListener('resize', updateBounds)
+    })()
+
+    readyRef.current = readyPromise
+
+    return () => {
+      disposed = true
+      resizeObserver?.disconnect()
+      window.removeEventListener('resize', handleResize)
+      readyRef.current = null
+
+      readyPromise
+        .then(() => window.webview.destroy(id))
+        .catch((error) => {
+          console.error('Failed to destroy webview', error)
+        })
+    }
+  }, [id, partition])
+
+  useEffect(() => {
+    let cancelled = false
+
+    const load = async () => {
+      try {
+        const ready = readyRef.current
+        if (ready) {
+          await ready
+        }
+        if (cancelled) {
+          return
+        }
+        await window.webview.load(id, url)
+        updateBoundsRef.current()
+      } catch (error) {
+        console.error('Failed to load url in webview', error)
+      }
     }
 
-    mount()
+    void load()
+
     return () => {
-      alive = false
-      ro?.disconnect()
-      window.removeEventListener('resize', () => {})
-      window.webview.destroy(id)
+      cancelled = true
     }
-  }, [id, url, partition, paddingTop, paddingLeft])
+  }, [id, url])
+
+  useEffect(() => {
+    updateBoundsRef.current()
+  }, [paddingTop, paddingLeft])
 
   // This div is just a placeholder; the real pixels are the BrowserView behind it
-  return <div ref={hostRef} className={className} />
+  return <div ref={hostRef} className={className} style={{ pointerEvents: 'none' }} />
 }

--- a/src/renderer/src/vite-env.d.ts
+++ b/src/renderer/src/vite-env.d.ts
@@ -1,12 +1,11 @@
 // src/vite-env.d.ts
+import type { AppApi, WebviewApi } from '../../shared/api'
+
 export {}
+
 declare global {
   interface Window {
-    webview: {
-      create(id:string, partition?:string): Promise<void>
-      setBounds(id:string, b:{x:number;y:number;width:number;height:number}): void
-      load(id:string, url:string): Promise<void>
-      destroy(id:string): Promise<void>
-    }
+    appApi: AppApi
+    webview: WebviewApi
   }
 }


### PR DESCRIPTION
## Summary
- expose the preload app API alongside the webview controls so the renderer can access version metadata safely
- rework the WebSurface component to manage BrowserView lifecycle, react to resizes, and release resources cleanly
- adjust the renderer layout and typings so the BrowserView lines up with the sidebar and keeps pointer events on the Electron surface

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6fb0489c8326ba6b74425226f6e8